### PR TITLE
Fixed a problem that did not work in environments other than English and Chinese.

### DIFF
--- a/bin/nosync.js
+++ b/bin/nosync.js
@@ -15,7 +15,7 @@ const pkg = require('../package');
 
 const locales = require('../locales/index.js'); // 语言包
 const locale = osLocale.sync().replace(/(_|-).*/, '').toLowerCase(); // 用户的语言环境
-const i18n = locales[locale];
+const i18n = locales[locale] ? locales[locale] : locales['en'];
 
 const spinner = ora('转化中 🐢 ...\n');
 


### PR DESCRIPTION
Thank you for providing a great tool!

It didn't work in my environment because the `locale` is `ja`.
So I've fixed it to work in environments where `locale` is not `zh` or `en`.